### PR TITLE
Update "extend" module to the latest 1.3.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "jscs": ">=1.0.5"
   },
   "dependencies": {
-    "extend": "1.1.3"
+    "extend": "1.3.0"
   }
 }


### PR DESCRIPTION
The deprecation message is annoying.

``` js
npm WARN deprecated extend@1.1.3: Please update to the latest version.
```

Then release please in npm, i will create PR-s for update objex in depentents
