### PR TITLE
Update dependencies

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -15,14 +15,12 @@
         "switch",
         "return"
     ],
-    "disallowLeftStickedOperators": [
-        "?",
+    "requireSpaceBeforeBinaryOperators": [
+        "=",
         "+",
         "-",
-        "/",
         "*",
-        ":",
-        "=",
+        "/",
         "==",
         "===",
         "!=",
@@ -32,13 +30,10 @@
         "<",
         "<="
     ],
-    "disallowRightStickedOperators": [
-        "!",
-        "?",
+    "requireSpaceAfterBinaryOperators": [
         "+",
         "/",
         "*",
-        ":",
         "=",
         "==",
         "===",
@@ -49,7 +44,11 @@
         "<",
         "<="
     ],
-    "requireLeftStickedOperators": [
+    "requireSpacesInConditionalExpression": true,
+    "requireSpaceAfterPrefixUnaryOperators": [
+        "!"
+    ],
+    "disallowSpaceBeforeBinaryOperators": [
         ","
     ],
     "disallowKeywords": [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "devDependencies": {
     "jshint": "2.1.x",
-    "jscs": "1.4.x",
+    "jscs": "1.13.x",
     "mocha": "^1.20.1",
     "chai": "^1.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "chai": "^1.9.1"
   },
   "dependencies": {
-    "extend": "1.3.0"
+    "extend": "3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     }
   ],
   "devDependencies": {
-    "jshint": "2.1.x",
-    "jscs": "1.13.x",
+    "jshint": "^2.1.0",
+    "jscs": "^1.13.0",
     "mocha": "^1.20.1",
     "chai": "^1.9.1"
   },
   "dependencies": {
-    "extend": "3.0.0"
+    "extend": "^3.0.0"
   }
 }


### PR DESCRIPTION
We use _nodules/luster_ in our projects. Suddenly we got `npm WARN deprecated extend@1.1.3: Please update to the latest version.` message. The reason of it was outdated dependencies in these library.

We update `extend` version. Also we update `jscs` version and fix issues with outdated `.jscs.json` rules to make tests passed.
